### PR TITLE
Add support for libp2p tunnel to ipfs-cluster

### DIFF
--- a/backplane.js
+++ b/backplane.js
@@ -75,8 +75,24 @@ const ready = async function () {
   return ipfs
 }()
 
+async function tunnel (clusterPeerId) {
+  const { stdout } = await execFile(
+    IPFS_BIN, [
+      'p2p',
+      'forward',
+      '--allow-custom-protocol',
+      '/libp2p-http',
+      `/ip4/127.0.0.1/tcp/29097`,
+      `/ipfs/${clusterPeerId}`
+    ],
+    { env: { 'IPFS_PATH': repoDir } }
+  )
+  log(stdout)
+}
+
 module.exports = {
-  ready
+  ready,
+  tunnel
 }
 
 

--- a/go-ipfs-config.json
+++ b/go-ipfs-config.json
@@ -68,7 +68,7 @@
   },
   "Experimental": {
     "FilestoreEnabled": false,
-    "Libp2pStreamMounting": false,
+    "Libp2pStreamMounting": true,
     "P2pHttpProxy": false,
     "QUIC": false,
     "ShardingEnabled": false,


### PR DESCRIPTION
If IPFS_CLUSTER_API matches /ip4/<ip-address>/tcp/<port>/ipfs/<peer-id> ,
then a libp2p tunnel will be configured to the ipfs-cluster.

Also added an optional IPFS_CLUSTER_LABEL setting to add a label to
the name of things pinned in ipfs-cluster.

Fixes #5