### PR TITLE
Add a queue for pinning and publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ipfs-http-client": "^30.0.0",
     "isomorphic-fetch": "^2.2.1",
     "lodash.debounce": "^4.0.8",
+    "p-queue": "^4.0.0",
     "peer-base": "^0.12.0-rc6",
     "tempy": "^0.2.1"
   }


### PR DESCRIPTION
Ensure only one pin/IPNS publish job happens at a time.

Pending CIDs overwrite previous pending CIDs, so that if a bunch
arrive at once, only the last gets pinned/published.

Eliminates some racy situations that would result in some CIDs never
getting unpinned. Fixes #4