### PR TITLE
Keep checking ipfs-cluster even if a node has pin_error

### DIFF
--- a/ipfs-cluster-api.js
+++ b/ipfs-cluster-api.js
@@ -78,7 +78,8 @@ async function pin (cid) {
         return (
           peer.status !== 'pinning' &&
           peer.status !== 'remote' &&
-          peer.status !== 'unpinned'
+          peer.status !== 'unpinned' &&
+          peer.status !== 'pin_error'
         )
       })
       if (notPinning) {


### PR DESCRIPTION
The pinning might succeed on other nodes.