### PR TITLE
Websocket proxy to backplane IPFS server

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,16 @@ A pinner for peer-base ... backup collaborations using IPFS, IPLD, IPNS + ipfs-c
 $ IPFS_HOME=/tmp/peer-base-pinner ipfs init
 $ cat << EOF > .env
 # Expose a websocket proxy (optional)
-WEBSOCKET_ANNOUNCE_HOST=my-peer-base-pinner.herokuapp.com
-WEBSOCKET_EXTERNAL_PORT=80
-## Starts a proxy and listens on /dns4/<host>/tcp/80/ws/ipfs/<backplane-peer-id>
+WEBSOCKET_ANNOUNCE_HOST=peer-base-pinner.example.com
+WEBSOCKET_EXTERNAL_PORT=8080
+## Starts a proxy and announces it as /dns4/<host>/tcp/<port>/ws/ipfs/<backplane-peer-id>
+##
+## If running on a platform such as Heroku that requires a 'Host' header in
+## order to route to the correct app, and because it is not currently possible
+## to embed 'Host' headers in multiaddrs, it maybe be necessary to manually
+## proxy through an additional layer (such as nginx) in order to add the
+## 'Host header. See: https://github.com/multiformats/multiaddr/issues/63
+## An example nginx config is shown below.
 
 # The IPFS cluster
 BOOTSTRAP1=/dns4/example.com/tcp/9097/ipfs/QmXXX
@@ -32,4 +39,22 @@ $ heroku config:push
 $ heroku maintenance:off
 # wait for it to start up
 $ heroku config:set IPNS_MODE=load
+```
+
+### Example nginx websocket proxy to add Host header
+
+```
+server {
+    listen 8080;
+    server_name peer-pad-pinner.example.com;
+    location / {
+        proxy_pass http://peer-pad-pinner.herokuapp.com:80;
+        proxy_cache_bypass $http_upgrade;
+        proxy_http_version 1.1;
+        proxy_set_header Host "peer-pad-pinner.herokuapp.com:80";
+        proxy_set_header Origin "http://peer-pad-pinner.herokuapp.com:80";
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+     }
+}
 ```

--- a/peer-pad-pinner
+++ b/peer-pad-pinner
@@ -54,7 +54,7 @@ function startHealthEndpointServer () {
   const metricsRegistry = require('./pinner-metrics')(pinner)
 
   const proxy = httpProxy.createProxyServer({
-    target: 'http://127.0.0.1:24002/ws',
+    target: 'ws://127.0.0.1:24002',
     ws: true
   })
 
@@ -71,6 +71,7 @@ function startHealthEndpointServer () {
       }
     })
     if (process.env.WEBSOCKET_ANNOUNCE_HOST) {
+      console.log('Jim upgrade!')
       server.on('upgrade', onUpgrade)
     }
     server.listen({ port, host }, () => {

--- a/peer-pad-pinner
+++ b/peer-pad-pinner
@@ -71,7 +71,6 @@ function startHealthEndpointServer () {
       }
     })
     if (process.env.WEBSOCKET_ANNOUNCE_HOST) {
-      console.log('Jim upgrade!')
       server.on('upgrade', onUpgrade)
     }
     server.listen({ port, host }, () => {
@@ -103,6 +102,7 @@ function startHealthEndpointServer () {
   }
 
   function onUpgrade (req, socket, head) {
+    console.log('Jim upgrade!', req, head)
     proxy.ws(req, socket, head)
   }
 

--- a/peer-pad-pinner
+++ b/peer-pad-pinner
@@ -96,6 +96,7 @@ function startHealthEndpointServer () {
         response.end(metricsRegistry.metrics())
         break
       default:
+        console.error('Jim 404', request.url, request.headers)
         response.writeHead(404)
         response.end('Not found')
     }

--- a/peer-pad-pinner
+++ b/peer-pad-pinner
@@ -96,14 +96,12 @@ function startHealthEndpointServer () {
         response.end(metricsRegistry.metrics())
         break
       default:
-        console.error('Jim 404', request.url, request.headers)
         response.writeHead(404)
         response.end('Not found')
     }
   }
 
   function onUpgrade (req, socket, head) {
-    console.log('Jim upgrade!', req, head)
     proxy.ws(req, socket, head)
   }
 


### PR DESCRIPTION
Create a websocket proxy to the backplane websocket server.

Also document how to setup nginx to add the Host header (needed by Heroku).