### PR TITLE
Try to catch proxy errors

### DIFF
--- a/peer-pad-pinner
+++ b/peer-pad-pinner
@@ -58,6 +58,10 @@ function startHealthEndpointServer () {
     ws: true
   })
 
+  proxy.on('error', e => {
+    console.error('Proxy error', e)
+  })
+
   return new Promise((resolve, reject) => {
     let started = false
 


### PR DESCRIPTION
On Heroku, the app was crashing, and it appears it was throwing
inside http-proxy. Try attaching an error handler to see if that
prevents the crashes.