### PR TITLE
Remove IPNS pinning / loading ... use ipfs-cluster names instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ WEBSOCKET_EXTERNAL_PORT=8080
 # The IPFS cluster
 BOOTSTRAP1=/dns4/example.com/tcp/9097/ipfs/QmXXX
 
-# Set IPNS_MODE to init on first run, then load
-IPNS_MODE=init
+# Set STARTUP_MODE to init on first run, then load-from-pinner
+STARTUP_MODE=init
 
 # ipfs-cluster stuff
 IPFS_CLUSTER_API=/dns4/example.com/tcp/9097/ipfs/QmXXX

--- a/index.js
+++ b/index.js
@@ -126,52 +126,33 @@ class AppPinner extends EventEmitter {
     })
     .then(async () => {
       if (
-        process.env.IPNS_MODE &&
-        process.env.IPNS_MODE.toLowerCase() == 'load'
+        process.env.LOAD_FROM
       ) {
         try {
-          const ipnsPath = `/ipns/${this.backplaneId}`
-          log('Resolving', ipnsPath)
-          let start = Date.now()
-          const name = await this.backplaneIpfs.resolve(ipnsPath)
-          let elapsed = `(${((Date.now() - start) / 1000).toFixed(1)}s)`
-          log('Resolved IPNS:', name, elapsed)
-          const hash = name.replace('/ipfs/', '')
+          const hash = process.env.LOAD_FROM
           log('Loading docIndex from IPFS', hash)
-          start = Date.now()
+          const start = Date.now()
           const result = await this.backplaneIpfs.dag.get(hash)
-          elapsed = `(${((Date.now() - start) / 1000).toFixed(1)}s)`
+          const elapsed = `(${((Date.now() - start) / 1000).toFixed(1)}s)`
           this.docIndex = result.value
-          log('docIndex loaded', elapsed)
-          if (!this.docIndex._created && !process.env.FORCE_CREATED) {
-            throw new Error('docIndex missing _created entry')
-          }
+          log(`docIndex loaded ${elapsed}, version ${this.docIndex._version}`)
           this.lastCid = hash
-          log('republishing to IPNS to refresh')
-          this.pinAndPublish(hash)
+          this.lastPinnedCid = hash
         } catch (e) {
-          log('Exception during IPNS resolve', e)
+          log('Exception during initial load', e)
           process.exit(1)
         }
-      } else if (
-        process.env.IPNS_MODE &&
-        process.env.IPNS_MODE.toLowerCase() == 'init'
-      ) {
+      } else {
         this.docIndex = {
-          _created: Date.now()
+          _created: Date.now(),
+          _version: 1
         }
         this.indexCid = await this.backplaneIpfs.dag.put(this.docIndex)
         const cidBase58 = this.indexCid.toBaseEncodedString()
         log('DocIndex CID (blank):', cidBase58)
-        await this.publish(cidBase58)
-        log('\nSet IPNS_MODE=load')
+        this.pin(cidBase58)
+        log('\nSet LOAD_FROM=<hash>')
         log('and restart to continue')
-        while (true) {
-          await delay(60 * 1000) // Infinite loop
-        }
-      } else {
-        log('\nFirst, set IPNS_MODE=init to create empty index on IPNS,')
-        log('and then set IPNS_MODE=load to load it.')
         while (true) {
           await delay(60 * 1000) // Infinite loop
         }
@@ -179,14 +160,16 @@ class AppPinner extends EventEmitter {
     })
     .then(() => {
       return new Promise((resolve, reject) => {
+        log('starting js-ipfs')
         const ipfsOptions = (this._options && this._options.ipfs) || {}
         this.ipfs = IPFS(this, ipfsOptions)
+        this.ipfs.on('error', (err) => this._handleIPFSError(err))
         if (this.ipfs.isOnline()) {
-          this.ipfs.on('error', (err) => this._handleIPFSError(err))
+          log('started js-ipfs')
           resolve()
         } else {
           this.ipfs.once('ready', () => {
-            this.ipfs.on('error', (err) => this._handleIPFSError(err))
+            log('started js-ipfs')
             resolve()
           })
         }
@@ -329,6 +312,7 @@ class AppPinner extends EventEmitter {
         const fqn = collaboration.fqn()
         const delta = collaboration.shared.stateAsDelta()
         const clock = delta[1]
+        const version = this.docIndex._version + 1
 
         log('Saving state:', fqn)
         Object.keys(clock).sort().forEach(key => {
@@ -353,7 +337,8 @@ class AppPinner extends EventEmitter {
           main: mainCid,
           clock,
           date: Date.now(),
-          subs: {}
+          subs: {},
+          version
         }
 
         for (let name of collaboration._subs.keys()) {
@@ -368,13 +353,11 @@ class AppPinner extends EventEmitter {
             cid
           }
         }
-        if (!this.docIndex._created && process.env.FORCE_CREATED) {
-          this.docIndex._created = Date.now()
-        }
+        this.docIndex._version = version
         this.indexCid = await this.backplaneIpfs.dag.put(this.docIndex)
         const cidBase58 = this.indexCid.toBaseEncodedString()
         log('DocIndex CID (updated):', cidBase58)
-        this.pinAndPublish(cidBase58)
+        this.pin(cidBase58)
         resetActivityTimeout()
       } catch (e) {
         log('Exception during update:', e)
@@ -412,48 +395,30 @@ class AppPinner extends EventEmitter {
     await this.ipfs.stop()
   }
 
-  async pinAndPublish (cidBase58) {
+  async pin (cidBase58) {
     this.pendingCid = cidBase58
     log('Queued', this.pendingCid)
     if (!this.queue) {
       this.queue = new PQueue({concurrency: 1})
     }
-    this.queue.add(() => this.pinAndPublishWorker())
+    this.queue.add(() => this.pinWorker())
   }
 
-  async pinAndPublishWorker () {
+  async pinWorker () {
     const cidBase58 = this.pendingCid
     if (!cidBase58) return
-    log('Pinning and publishing', cidBase58)
+    log('Pinning', cidBase58)
     this.pendingCid = null
     const prevCid = this.lastPinnedCid
     if (cidBase58 !== this.lastPinnedCid) {
-      await cluster.pin(cidBase58)
+      await cluster.pin(cidBase58, this.docIndex._version, this.backplaneId)
       this.lastPinnedCid = cidBase58
-    }
-    if (cidBase58 !== this.lastPublishedCid) {
-      await this.publish(cidBase58)
-      this.lastPublishedCid = cidBase58
     }
     if (prevCid && prevCid !== cidBase58) {
       await cluster.unpin(prevCid)
     }
-    log('Pinned and published', cidBase58)
-  }
-
-  async publish (cidBase58) {
-    const ipfsPath = `/ipfs/${cidBase58}`
-    log('Updating IPNS...', ipfsPath)
-    const start = Date.now()
-    try {
-      await this.backplaneIpfs.name.publish(ipfsPath)
-      const elapsed = `(${((Date.now() - start) / 1000).toFixed(1)}s)`
-      const ipnsPath = `/ipns/${this.backplaneId}`
-      log('IPNS updated:', ipnsPath, elapsed)
-      log('  CID:', cidBase58)
-    } catch (e) {
-      log('IPNS Exception:', e)
-    }
+    log('Pinned', cidBase58)
+    await delay(30000)
   }
 
   async loadBackupsFromIpfs (name) {

--- a/ipfs-cluster-api.js
+++ b/ipfs-cluster-api.js
@@ -117,8 +117,28 @@ async function unpin (cid) {
   }
 }
 
+async function getPins () {
+  const apiBaseUrl = new URL(apiBase)
+  const apiPinLs = new URL(`/allocations?filter=all`, apiBaseUrl)
+  log(`listing pins on cluster`)
+  const res = await fetch(
+    apiPinLs.href,
+    {
+      headers: {
+        'Authorization': `Basic ${auth}`
+      }
+    }
+  )
+  if (!res.ok) {
+    throw new Error('Pin ls failed')
+  }
+  const json = await res.json()
+  return json
+}
+
 module.exports = {
   useTunnel,
   pin,
-  unpin
+  unpin,
+  getPins
 }

--- a/ipfs-cluster-api.js
+++ b/ipfs-cluster-api.js
@@ -18,15 +18,15 @@ function useTunnel () {
   apiBase = 'http://127.0.0.1:29097'
 }
 
-async function pin (cid) {
+async function pin (cid, version, peerId) {
   const apiBaseUrl = new URL(apiBase)
-  let name = 'peer-base-pinner'
+  let name = `peer-base-pinner: ${version} ${peerId}`
   if (process.env.IPFS_CLUSTER_LABEL) {
-    name += `: ${process.env.IPFS_CLUSTER_LABEL}`
+    name += ` ${process.env.IPFS_CLUSTER_LABEL}`
   }
   const opts = `name=${encodeURIComponent(name)}`
   const apiPinAdd = new URL(`/pins/${cid}?${opts}`, apiBaseUrl)
-  log(`pinning ${cid} to cluster`)
+  log(`pinning ${cid} to cluster, version ${version}`)
   const start = Date.now()
   const res = await fetch(
     apiPinAdd.href,
@@ -72,7 +72,7 @@ async function pin (cid) {
       })
       if (finished) {
         const elapsed = `(${((Date.now() - start) / 1000).toFixed(1)}s)`
-        log('pinned', cid, elapsed)
+        log('pinned', version, cid, elapsed)
         break
       }
       const notPinning = Object.keys(json.peer_map).some(peerId => {


### PR DESCRIPTION
IPNS was just acting way too random - it was slow, and often would resolve to the wrong version.

This scheme records a version number in the name used when pinning to IPFS cluster. On startup, it will retrieve all the pinned records and pick the lowest version, deleting the rest, as they may not be fully pinned.

In normal operation, there should only be one version pinned to the cluster, unless a pinning request is in-flight.